### PR TITLE
Require twipsy before popover

### DIFF
--- a/vendor/assets/javascripts/twitter/bootstrap.js
+++ b/vendor/assets/javascripts/twitter/bootstrap.js
@@ -1,7 +1,7 @@
 //= require twitter/bootstrap/alerts
 //= require twitter/bootstrap/dropdown
 //= require twitter/bootstrap/modal
+//= require twitter/bootstrap/twipsy
 //= require twitter/bootstrap/popover
 //= require twitter/bootstrap/scrollspy
 //= require twitter/bootstrap/tabs
-//= require twitter/bootstrap/twipsy


### PR DESCRIPTION
Popover extends Twipsy and so twipsy needs to be "required" before popover https://github.com/twitter/bootstrap/blob/master/js/bootstrap-popover.js#L30

In development mode, i have not faced a problem but in production (ex. heroku), this throws : Uncaught TypeError: Cannot read property 'Twipsy' of undefined

Disclaimer : I am not using this gem currently but would **love** to replace my manual less setup with this
