### PR TITLE
Problem precompiling assets under Rails 3.1.1.rc2 

### DIFF
--- a/lib/less/rails/bootstrap/engine.rb
+++ b/lib/less/rails/bootstrap/engine.rb
@@ -3,7 +3,7 @@ module Less
     module Bootstrap
       class Engine < ::Rails::Engine
 
-        initializer 'less-rails-bootstrap.setup', :before => 'less-rails.after-setup', :group => :assets do |app|
+        initializer 'less-rails-bootstrap.setup', :before => 'less-rails.after-setup', :group => :all do |app|
           bootstrap_less_files = config.root + 'vendor/assets/stylesheets/twitter'
           app.config.less.paths << bootstrap_less_files
         end


### PR DESCRIPTION
Hey Ken,

Rails 3.1.1 seems to introduce grouped initializers and uses a special group called "assets" when running the `assets:precompile` Rake task. This in combination leads to the fact, that your initializers will not be run when invoking that task: a pitty! :) I've changed the initializers to the way they work now.

I will also request a pull in your less-rails project, which is affected by the same.

Oh! I also had to change the assets path in the engine. Don't know if that's strange.

Cheers,

Thorben
