### PR TITLE
Bumping the less-rails depedency so everyone can use therubyracer 0.10.0

### DIFF
--- a/less-rails-bootstrap.gemspec
+++ b/less-rails-bootstrap.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_runtime_dependency "less-rails", "~> 2.1.0"
+  s.add_runtime_dependency "less-rails", "~> 2.2.0"
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'guard-minitest'
   s.add_development_dependency 'rails',  '~> 3.1'

--- a/lib/less/rails/bootstrap/version.rb
+++ b/lib/less/rails/bootstrap/version.rb
@@ -1,7 +1,7 @@
 module Less
   module Rails
     module Bootstrap
-      VERSION = "2.0.8"
+      VERSION = "2.0.9"
     end
   end
 end


### PR DESCRIPTION
We're using the new version of less-rails but would like to use some of the Twitter bootstrap stuff.
