### PR TITLE
fix for "undefined method `less'"?

### DIFF
--- a/lib/less/rails/bootstrap/engine.rb
+++ b/lib/less/rails/bootstrap/engine.rb
@@ -1,14 +1,15 @@
 require 'rails'
+require 'less'
 
 module Less
   module Rails
     module Bootstrap
       class Engine < ::Rails::Engine
-        
+
         initializer 'less-rails-bootstrap.setup', :after => 'less-rails.after.load_config_initializers', :group => :all do |app|
           app.config.less.paths << File.join(config.root, 'vendor', 'frameworks')
         end
-        
+
       end
     end
   end


### PR DESCRIPTION
got the:

```
...
railties-3.2.8/lib/rails/railtie/configuration.rb:85:in `method_missing': undefined method `less' for #<Rails::Application::Configuration:0x00000004004c50> (NoMethodError)
...
```
