### PR TITLE
fix font path according to asset pipeline

### DIFF
--- a/app/frameworks/twitter/bootstrap/variables.less
+++ b/app/frameworks/twitter/bootstrap/variables.less
@@ -58,7 +58,7 @@
 // Iconography
 // -------------------------
 
-@icon-font-path:          "../fonts/";
+@icon-font-path:          "../../bootstrap/";
 @icon-font-name:          "glyphicons-halflings-regular";
 
 

--- a/test/cases/usage_css_spec.rb
+++ b/test/cases/usage_css_spec.rb
@@ -21,7 +21,7 @@ class UsageCssSpec < Less::Rails::Bootstrap::Spec
     let(:app_css) { dummy_asset('fonts.css.less') }
 
     it 'uses less-rails asset-url helper for fonts' do
-      app_css.must_include "url('twitter/bootstrap/../fonts/glyphicons-halflings-regular.eot')"
+      app_css.must_include "url('twitter/bootstrap/../../bootstrap/glyphicons-halflings-regular.eot')"
     end
 
   end


### PR DESCRIPTION
Because asset pipeline disregards sub-directory name for assets, (e.g. fonts, images .. etc.) less variable for font path should be revised.

With original setup, `@icon-font-path:          "../fonts/";` makes asset path of `/assets/twitter/twitter/fonts/`.
However, the right path is `/assets/twitter/bootstrap/`. So I changed `@icon-font-path` accordingly.
