### PR TITLE
possible bug

### DIFF
--- a/app/frameworks/twitter/bootstrap/forms.less
+++ b/app/frameworks/twitter/bootstrap/forms.less
@@ -327,30 +327,30 @@ input[type="checkbox"] {
   .form-control {
     padding-right: (@input-height-base * 1.25);
   }
-}
-// Feedback icon (requires .glyphicon classes)
-.form-control-feedback {
-  position: absolute;
-  top: (@line-height-computed + 5); // Height of the `label` and its margin
-  right: 0;
-  z-index: 2; // Ensure icon is above input groups
-  display: block;
-  width: @input-height-base;
-  height: @input-height-base;
-  line-height: @input-height-base;
-  text-align: center;
-}
-.input-lg + .form-control-feedback {
-  width: @input-height-large;
-  height: @input-height-large;
-  line-height: @input-height-large;
-}
-.input-sm + .form-control-feedback {
-  width: @input-height-small;
-  height: @input-height-small;
-  line-height: @input-height-small;
-}
 
+// Feedback icon (requires .glyphicon classes)
+  .form-control-feedback {
+    position: absolute;
+    top: (@line-height-computed + 5); // Height of the `label` and its margin
+    right: 0;
+    z-index: 2; // Ensure icon is above input groups
+    display: block;
+    width: @input-height-base;
+    height: @input-height-base;
+    line-height: @input-height-base;
+    text-align: center;
+  }
+  .input-lg + .form-control-feedback {
+    width: @input-height-large;
+    height: @input-height-large;
+    line-height: @input-height-large;
+  }
+  .input-sm + .form-control-feedback {
+    width: @input-height-small;
+    height: @input-height-small;
+    line-height: @input-height-small;
+  }
+}
 // Feedback states
 .has-success {
   .form-control-validation(@state-success-text; @state-success-text; @state-success-bg);


### PR DESCRIPTION
@ejmm320 and @alfredorico propose that .form-control-feedback, input-lg and input-sm has been isolated and we think that must be inside .has-feedback { } group
We have experienced issues with span form-control-feedback on errors form feedback 
If you look at version 3.1.1.0, .form-control-feedback, input-lg and input-sm were inside .has-feedback { } group
