### PR TITLE
Require most recent version of less-rails

### DIFF
--- a/less-rails-bootstrap.gemspec
+++ b/less-rails-bootstrap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
-  gem.add_runtime_dependency     'less-rails', '~> 2.6.0'
+  gem.add_runtime_dependency     'less-rails', '~> 2.7.0'
 
   gem.add_development_dependency 'minitest', '>= 4.0'
   gem.add_development_dependency 'guard-minitest'


### PR DESCRIPTION
Rails 4.2.1 dies if less-rails is older than 2.7.0.

Calling `stylesheet_link_tag` crashes with `undefined method `[]' for nil:NilClass`.  Upgrading to 2.7.0 fixes it.  Likely related to https://github.com/metaskills/less-rails/commit/97f002d61b3b720a984b98d3492940ac6ff66d41