### PR TITLE
Use less-rails on 2.3.3 branch

### DIFF
--- a/less-rails-bootstrap.gemspec
+++ b/less-rails-bootstrap.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
-  gem.add_runtime_dependency     'less-rails', '~> 2.3.1'
+  gem.add_runtime_dependency     'less-rails', ['>= 2.6', '<= 2.8']
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'guard-minitest'
   gem.add_development_dependency 'rails',  '~> 3.1'

--- a/lib/less/rails/bootstrap/version.rb
+++ b/lib/less/rails/bootstrap/version.rb
@@ -1,7 +1,7 @@
 module Less
   module Rails
     module Bootstrap
-      VERSION = "2.3.3"
+      VERSION = "2.3.4"
     end
   end
 end


### PR DESCRIPTION
One of our apps still depend on bootstrap 2 and we no longer put a lot of effort into maintaining it.
However we have to update it to Rails5 according to our internal policy.

Since rails5 require a higher version of less-rails, this PR allows less-rails-bootstrap 2.3.4 to use less-rails 2.8 as in the master branch of less-rails-bootstrap.

**Note**: This should be merged with tag: v2.3.3 and created a new tag: v2.3.4, not with master