### PR TITLE
Latest less-rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,41 @@
+language: ruby
+cache: bundler
+sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
-  - jruby-19mode
+  - 1.9.3-p551
+  - 2.0.0-p648
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - jruby-9.1.9.0
 before_install:
-  - travis_retry gem install bundler
-  - bundle --version
+  - gem install bundler
 install:
-  - travis_retry bundle install
-before_script:
-  - travis_retry bundle exec appraisal install
+  - bundle install --jobs=3 --retry=3
 script:
-  - bundle exec appraisal rake test
+  - bundle exec rake
+gemfile:
+  - gemfiles/rails40.gemfile
+  - gemfiles/rails41.gemfile
+  - gemfiles/rails42.gemfile
+  - gemfiles/rails50.gemfile
+  - gemfiles/rails51.gemfile
+matrix:
+  exclude:
+    - rvm: 1.9.3-p551
+      gemfile: gemfiles/rails50.gemfile
+    - rvm: 1.9.3-p551
+      gemfile: gemfiles/rails51.gemfile
+    - rvm: 2.0.0-p648
+      gemfile: gemfiles/rails50.gemfile
+    - rvm: 2.0.0-p648
+      gemfile: gemfiles/rails51.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails50.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails51.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails40.gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/rails41.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,19 @@
-appraise "rails31" do
-  gem "rails", "~> 3.1.12"
-  gem "minitest", "~> 4.7.5"
-end if RUBY_VERSION < '2.0.0'
-
-appraise "rails32" do
-  gem "rails", "~> 3.2.17"
-  gem "minitest", "~> 4.7.5"
+appraise 'rails40' do
+  gem 'rails', '~> 4.0.13'
 end
 
-appraise "rails40" do
-  gem "rails", "~> 4.0.4"
+appraise 'rails41' do
+  gem 'rails', '~> 4.1.16'
 end
 
-appraise "rails41" do
-  gem "rails", "~> 4.1.0"
+appraise 'rails42' do
+  gem 'rails', '~> 4.2.8'
 end
 
-appraise "rails42" do
-  gem "rails", "~> 4.2.0"
+appraise 'rails50' do
+  gem 'rails', '~> 5.0.3'
+end
+
+appraise 'rails51' do
+  gem 'rails', '~> 5.1.1'
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Here are the steps to update the version of twitter bootstrap used.
 * Run the tests by doing:
 
 ```
-$ bundle install
-$ bundle exec rake appraisal:setup
-$ bundle exec rake appraisal test
+$ bundle
+$ bundle exec appraisal install
+$ bundle exec appraisal rake
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "therubyracer", ">= 0.10.1", :require => nil, :platforms => :ruby
-gem "therubyrhino", ">= 1.73.2", :require => nil, :platforms => :jruby
-
+gem "therubyracer", "~> 0.12.0", :require => nil, :platforms => :ruby
+gem "therubyrhino", "~> 2.0.2", :require => nil, :platforms => :jruby

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bootstrap is Twitter's toolkit for kickstarting your site or app's CSS. It includes base styles for typography, forms, buttons, tables, grid layout, navigation, alerts, and more. To get started -- check out the [Bootstrap docs](http://getbootstrap.com/).
 
-The less-rails-bootstrap project hooks into [less-rails](http://github.com/metaskills/less-rails) and [less.rb](http://github.com/cowboyd/less.rb), making Bootstrap's source LESS files, compiled CSS, and JavaScript files available in the Rails 3.x and 4.x asset pipeline.
+The less-rails-bootstrap project hooks into [less-rails](http://github.com/metaskills/less-rails) and [less.rb](http://github.com/cowboyd/less.rb), making Bootstrap's source LESS files, compiled CSS, and JavaScript files available in the Rails 4.x and 5.x asset pipeline.
 
 The benefits:
 
@@ -87,18 +87,18 @@ This gem will directly track the semantic versioning of the Twitter Bootstrap pr
 
 ## Contributing
 
-This gem is fully tested from Rails 3.1 to 4.1. We run our tests on [Travis CI](http://travis-ci.org/metaskills/less-rails-boostrap) in both Ruby 1.9, 2.0, 2.1, and jRuby 1.9 mode. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
+This gem is fully tested from Rails 4.0 to 5.2. We run our tests on [Travis CI](http://travis-ci.org/metaskills/less-rails-boostrap) in both Ruby 1.9, 2.0  and jRuby 9000. If you detect a problem, open up a github issue or fork the repo and help out. After you fork or clone the repository, the following commands will get you up and running on the test suite.
 
 ```shell
-$ bundle install
+$ bundle
 $ bundle exec appraisal install
-$ bundle exec appraisal rake test
+$ bundle exec appraisal test
 ```
 
-We use the [appraisal](https://github.com/thoughtbot/appraisal) gem from Thoughtbot to help us generate the individual gemfiles for each Rails version and to run the tests locally against each generated Gemfile. The `appraisal rake test` command actually runs our test suite against all Rails versions in our `Appraisal` file. If you want to run the tests for a specific Rails version, use `rake -T` for a list. For example, the following command will run the tests for Rails 3.2 only.
+We use the [appraisal](https://github.com/thoughtbot/appraisal) gem from Thoughtbot to help us generate the individual gemfiles for each Rails version and to run the tests locally against each generated Gemfile. The `appraisal test` command actually runs our test suite against all Rails versions in our `Appraisal` file. If you want to run the tests for a specific Rails version, use `rake -T` for a list. For example, the following command will run the tests for Rails 4.0 only.
 
 ```shell
-$ bundle exec appraisal rails32 rake test
+$ bundle exec appraisal rails40 rake test
 ```
 
 Our current build status is:

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
-require 'bundler'
+require 'rubygems'
+require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'appraisal'
-
-Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new do |t|
   t.libs = ['lib','test']

--- a/less-rails-bootstrap.gemspec
+++ b/less-rails-bootstrap.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
-  gem.add_runtime_dependency     'less-rails', ['>= 2.6', '<= 2.8']
+  gem.add_runtime_dependency     'less-rails', '>= 3.0'
 
   gem.add_development_dependency 'minitest', '>= 4.0'
   gem.add_development_dependency 'guard-minitest'
   gem.add_development_dependency 'guard'
-  gem.add_development_dependency 'rails',  ['>= 3.1', '<= 4.2']
+  gem.add_development_dependency 'rails',  '>= 4.0'
   gem.add_development_dependency 'appraisal'
 end


### PR DESCRIPTION
Thanks a lot for maintaining this gem.

We use it in one of our production apps which is running on rails 4.2. Upgrading to the latest ruby/rails offers us to upgrade less-rails which is a dependency on less-rails-bootstrap.

This PR is about to upgrade this gem to the latest available less-rails:

https://github.com/metaskills/less-rails/compare/v2.8.0...v3.0.0

This addresses #131 and #130 

I hope the PR is ok and you will be able to review/merge it ❤️ 

